### PR TITLE
adding proton command with list and prune sub commands

### DIFF
--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -73,11 +73,14 @@ export function requireOsHandler<T>(
   return handler;
 }
 
+export function withBaseOptions(cmd: Command) {
+  return cmd.option('-v, --verbose', 'Show verbose output');
+}
+
 export function withCommonGameOptions(cmd: Command) {
-  return cmd
+  return withBaseOptions(cmd)
     .option(
       '-a, --appId <appId:string>',
       'The AppId to use when filtering by name is ambiguous',
-    )
-    .option('-v, --verbose', 'Show verbose output');
+    );
 }

--- a/src/commands/proton/commands/list.ts
+++ b/src/commands/proton/commands/list.ts
@@ -1,0 +1,73 @@
+import { Command } from '@cliffy/command';
+import { join } from '@std/path';
+import { requireOsHandler, withBaseOptions } from '../../command-helpers.ts';
+import { createLogger, Logger } from '../../../core/logger.ts';
+import { protonPrefixDir } from '../../../core/steam/paths.ts';
+import { Table } from '@cliffy/table';
+import { IGNORE_VERSIONS } from '../constants.ts';
+import { dirSize, sizeToHumanReadable } from '../../../core/utils.ts';
+import { getProtonMappings } from '../../../core/steam/proton.ts';
+
+const linuxHandler = async (logger: Logger) => {
+  const rootDir = protonPrefixDir();
+
+  const protonVersions = new Set<string>();
+  logger.info(`Listing Proton versions installed in ${rootDir}...`);
+  for await (const entry of Deno.readDir(rootDir)) {
+    if (entry.isDirectory) {
+      if (!IGNORE_VERSIONS.includes(entry.name)) {
+        if (logger.isDebugEnabled()) {
+          const size = await dirSize(join(rootDir, entry.name));
+          const humanSize = sizeToHumanReadable(size);
+          logger.debug(`Found Proton version ${entry.name} @ ${humanSize}`);
+        }
+        protonVersions.add(entry.name);
+      }
+    }
+  }
+
+  const games = await getProtonMappings();
+
+  // Print alphabetized list
+  let foundUnusedProtonVersions = false;
+  logger.info(`Found ${protonVersions.size} Proton versions:`);
+  const alphabeticalSorter = (a: string, b: string) => a.localeCompare(b);
+  const sortedVersions = [...protonVersions].sort(alphabeticalSorter);
+  for (const version of sortedVersions) {
+    const matchingGames = games.filter((e) => e.protonVersion === version).sort(
+      (a, b) => alphabeticalSorter(a.name, b.name),
+    );
+    if (matchingGames.length > 0) {
+      const table = new Table()
+        .body(matchingGames.map((e, i) => [i + 1, e.name]))
+        .header(['', version])
+        .border(true);
+      logger.info(table.toString());
+    } else {
+      foundUnusedProtonVersions = true;
+      logger.info(`  ${version} (no games using this version)`);
+    }
+  }
+
+  if (foundUnusedProtonVersions) {
+    logger.info(
+      'Some Proton versions are not used by any games. You can remove them to save disk space with `steamy proton prune`.',
+    );
+  }
+};
+
+export const list = withBaseOptions(
+  new Command()
+    .name('list')
+    .description(
+      'Lists installed Proton versions and which games are using them',
+    ),
+)
+  .action(async ({ verbose }) => {
+    const logger = createLogger(verbose);
+
+    const handler = requireOsHandler({
+      linux: linuxHandler,
+    });
+    await handler(logger);
+  });

--- a/src/commands/proton/commands/prune.ts
+++ b/src/commands/proton/commands/prune.ts
@@ -1,0 +1,87 @@
+import { Command } from '@cliffy/command';
+import { join } from '@std/path';
+import { requireOsHandler, withBaseOptions } from '../../command-helpers.ts';
+import { createLogger, Logger } from '../../../core/logger.ts';
+import { protonPrefixDir } from '../../../core/steam/paths.ts';
+import { Checkbox } from '@cliffy/prompt/checkbox';
+import { dirSize, sizeToHumanReadable } from '../../../core/utils.ts';
+import {
+  getInstalledProtonVersions,
+  getProtonMappings,
+  getUnusedProtonVersions,
+} from '../../../core/steam/proton.ts';
+
+const linuxHandler = async (logger: Logger) => {
+  const rootDir = protonPrefixDir();
+  logger.info(`Scanning for unused Proton versions in ${rootDir}...`);
+
+  const protonVersions = await getInstalledProtonVersions({ rootDir });
+  const games = await getProtonMappings();
+
+  const unusedProtonVersions = getUnusedProtonVersions(games, [
+    ...protonVersions,
+  ]);
+  if (unusedProtonVersions.length > 0) {
+    logger.info(
+      `Found ${unusedProtonVersions.length} unused Proton versions. Calculating size(s)...`,
+    );
+    const withSizes = await Promise.all(
+      unusedProtonVersions.map(async (version) => {
+        const size = await dirSize(join(rootDir, version));
+        return { version, size, humanSize: sizeToHumanReadable(size) };
+      }),
+    );
+
+    // Ask the user to confirm the proton versions to remove
+    const selectedVersions: string[] = await Checkbox.prompt({
+      message:
+        'Use space to toggle, Enter to confirm. Select the Proton versions to remove:',
+      options: [
+        ...withSizes.sort((a, b) => a.version.localeCompare(b.version)).map((
+          e,
+        ) => ({
+          name: `${e.version} - ${e.humanSize}`,
+          value: e.version,
+        })),
+      ],
+    });
+    if (selectedVersions.length > 0) {
+      const totalSize = selectedVersions.reduce(
+        (acc, version) =>
+          acc + withSizes.find((e) => e.version === version)?.size || 0,
+        0,
+      );
+      logger.info(
+        `Removing Proton versions: ${
+          selectedVersions.join(', ')
+        } for a total recovery of ${sizeToHumanReadable(totalSize)}`,
+      );
+
+      await Promise.all(selectedVersions.map(async (version) => {
+        const path = join(rootDir, version);
+        if (logger.isDebugEnabled()) {
+          logger.debug(`Removing Proton version ${version} @ ${path}`);
+        }
+        await Deno.remove(path, { recursive: true });
+      }));
+    }
+  } else {
+    logger.info('No unused Proton versions found!');
+  }
+};
+
+export const prune = withBaseOptions(
+  new Command()
+    .name('prune')
+    .description(
+      'Removes unused Proton versions to save disk space.',
+    ),
+)
+  .action(async ({ verbose }) => {
+    const logger = createLogger(verbose);
+
+    const handler = requireOsHandler({
+      linux: linuxHandler,
+    });
+    await handler(logger);
+  });

--- a/src/commands/proton/constants.ts
+++ b/src/commands/proton/constants.ts
@@ -1,0 +1,3 @@
+export const IGNORE_VERSIONS = [
+  'LegacyRuntime',
+];

--- a/src/commands/proton/proton.ts
+++ b/src/commands/proton/proton.ts
@@ -1,0 +1,13 @@
+import { Command, ValidationError } from '@cliffy/command';
+import { list } from './commands/list.ts';
+import { prune } from './commands/prune.ts';
+
+export const proton = new Command()
+  .name('proton')
+  .description('Helpers to manage Proton versions')
+  .usage('<sub-command [OPTIONS]>')
+  .action(() => {
+    throw new ValidationError('Missing sub-command');
+  })
+  .command('list', list)
+  .command('prune', prune);

--- a/src/core/games/match.ts
+++ b/src/core/games/match.ts
@@ -10,21 +10,20 @@ import { parseSteamCacheFile } from '../steam/cache-parser.ts';
 import { SteamyError } from '../errors.ts';
 
 /**
- * Finds Steam games matching the provided name
- * @param gameName - A partial segment of the name of the game to search for
- * @returns Promise<GameMatch[]> Array of matching games with their app IDs
- * @throws SteamyError if Steam directory is inaccessible
+ * Scans the Steam apps cache directory and returns parsed cache fragments
+ * for every `.acf` file found.
+ *
+ * This is a general-purpose building block intended to be consumed by
+ * `findAppIdMatches` and other features that need raw cache metadata.
+ *
+ * @returns Promise<CacheFileFragment[]> Array of cache fragments from all appmanifest files
+ * @throws SteamyError if Steam directory is inaccessible or parsing fails
  */
-export async function findAppIdMatches(gameName: string): Promise<GameMatch[]> {
-  if (!gameName || typeof gameName !== 'string') {
-    throw new Error('Game name must be a non-empty string');
-  }
-
-  const gameDir = steamAppsDir();
-  const gameNameUpper = gameName.toLocaleUpperCase();
-  const matches: GameMatch[] = [];
-
+export async function scanSteamCacheFragments(): Promise<CacheFileFragment[]> {
   try {
+    const fragments: CacheFileFragment[] = [];
+    const gameDir = steamAppsDir();
+
     const acfFiles: string[] = [];
     for await (const entry of Deno.readDir(gameDir)) {
       if (entry.name.endsWith('.acf')) {
@@ -44,15 +43,12 @@ export async function findAppIdMatches(gameName: string): Promise<GameMatch[]> {
     );
 
     for await (const meta of results) {
-      const nameUpper = meta.AppState.name.toLocaleUpperCase();
-      if (nameUpper.indexOf(gameNameUpper) > -1) {
-        matches.push({
-          appId: meta.AppState.appid,
-          name: meta.AppState.name,
-        });
-      }
+      fragments.push(meta);
     }
+
+    return fragments;
   } catch (error: unknown) {
+    // Preserve existing error wrapping semantics
     const errorMessage = error instanceof Error
       ? error.message
       : 'Unknown error';
@@ -62,5 +58,32 @@ export async function findAppIdMatches(gameName: string): Promise<GameMatch[]> {
       'Ensure Steam is installed and you have read permissions to the SteamApps directory',
     );
   }
+}
+
+/**
+ * Finds Steam games matching the provided name
+ * @param gameName - A partial segment of the name of the game to search for
+ * @returns Promise<GameMatch[]> Array of matching games with their app IDs
+ * @throws SteamyError if Steam directory is inaccessible
+ */
+export async function findAppIdMatches(gameName: string): Promise<GameMatch[]> {
+  if (!gameName || typeof gameName !== 'string') {
+    throw new Error('Game name must be a non-empty string');
+  }
+
+  const gameNameUpper = gameName.toLocaleUpperCase();
+  const matches: GameMatch[] = [];
+
+  const fragments = await scanSteamCacheFragments();
+  for (const meta of fragments) {
+    const nameUpper = meta.AppState.name.toLocaleUpperCase();
+    if (nameUpper.indexOf(gameNameUpper) > -1) {
+      matches.push({
+        appId: meta.AppState.appid,
+        name: meta.AppState.name,
+      });
+    }
+  }
+
   return matches;
 }

--- a/src/core/steam/paths.ts
+++ b/src/core/steam/paths.ts
@@ -37,6 +37,13 @@ export function compatDataDir(appId: string) {
 }
 
 /**
+ * Returns the path to the Proton prefix directory
+ */
+export function protonPrefixDir() {
+  return join(steamRootDir(), 'compatibilitytools.d');
+}
+
+/**
  * Returns the path to the common directory for the specified game
  * @param folderName - The name of the game folder
  */

--- a/src/core/steam/proton.test.ts
+++ b/src/core/steam/proton.test.ts
@@ -1,0 +1,281 @@
+import { assertEquals, assertRejects } from '@std/assert';
+import { stub } from '@std/testing/mock';
+import { join } from '@std/path';
+
+import {
+  getCompatToolMappings,
+  getInstalledProtonVersions,
+  getProtonMappings,
+  getUnusedProtonVersions,
+} from './proton.ts';
+import { SteamyError } from '../errors.ts';
+
+function makeDirEntries(
+  entries: Array<
+    {
+      name: string;
+      isDirectory?: boolean;
+      isFile?: boolean;
+      isSymlink?: boolean;
+    }
+  >,
+): AsyncIterable<Deno.DirEntry> {
+  async function* gen() {
+    for (const e of entries) {
+      yield {
+        name: e.name,
+        isFile: e.isFile ?? false,
+        isDirectory: e.isDirectory ?? false,
+        isSymlink: e.isSymlink ?? false,
+      } as Deno.DirEntry;
+    }
+  }
+  return { [Symbol.asyncIterator]: gen } as AsyncIterable<Deno.DirEntry>;
+}
+
+Deno.test('getCompatToolMappings returns mapping from config.vdf', async () => {
+  const envStub = stub(
+    Deno.env,
+    'get',
+    (key: string) => (key === 'HOME' ? '/home/test' : undefined),
+  );
+
+  const configPath = join(
+    '/home/test',
+    '.steam',
+    'steam',
+    'config',
+    'config.vdf',
+  );
+  const body = [
+    'InstallConfigStore',
+    '{',
+    '\tSoftware',
+    '\t{',
+    '\t\tValve',
+    '\t\t{',
+    '\t\t\tSteam',
+    '\t\t\t{',
+    '\t\t\t\tCompatToolMapping',
+    '\t\t\t\t{',
+    '\t\t\t\t\t12345',
+    '\t\t\t\t\t{',
+    '\t\t\t\t\t\tname\tproton-8.0',
+    '\t\t\t\t\t}',
+    '\t\t\t\t\t99999',
+    '\t\t\t\t\t{',
+    '\t\t\t\t\t\tname\tGE-Proton9-2',
+    '\t\t\t\t\t}',
+    '\t\t\t\t}',
+    '\t\t\t}',
+    '\t\t}',
+    '\t}',
+    '}',
+  ].join('\n');
+
+  const readTextStub = stub(
+    Deno,
+    'readTextFile',
+    (path: string | URL): Promise<string> => {
+      if (String(path) !== configPath) {
+        return Promise.reject(new Error('Unexpected path: ' + String(path)));
+      }
+      return Promise.resolve(body);
+    },
+  );
+
+  try {
+    const map = await getCompatToolMappings();
+    assertEquals(map['12345'].name, 'proton-8.0');
+    assertEquals(map['99999'].name, 'GE-Proton9-2');
+  } finally {
+    readTextStub.restore();
+    envStub.restore();
+  }
+});
+
+Deno.test('getProtonMappings aggregates fragments with compat tool versions', async () => {
+  const envStub = stub(
+    Deno.env,
+    'get',
+    (key: string) => (key === 'HOME' ? '/home/alice' : undefined),
+  );
+
+  // Stub reading the config.vdf used by getCompatToolMappings
+  const configPath = join(
+    '/home/alice',
+    '.steam',
+    'steam',
+    'config',
+    'config.vdf',
+  );
+  const configBody = [
+    'InstallConfigStore',
+    '{',
+    '\tSoftware',
+    '\t{',
+    '\t\tValve',
+    '\t\t{',
+    '\t\t\tSteam',
+    '\t\t\t{',
+    '\t\t\t\tCompatToolMapping',
+    '\t\t\t\t{',
+    '\t\t\t\t\t111',
+    '\t\t\t\t\t{',
+    '\t\t\t\t\t\tname\tProton-8.0',
+    '\t\t\t\t\t}',
+    '\t\t\t\t}',
+    '\t\t\t}',
+    '\t\t}',
+    '\t}',
+    '}',
+  ].join('\n');
+
+  const readTextStub = stub(
+    Deno,
+    'readTextFile',
+    (path: string | URL): Promise<string> => {
+      if (String(path) === configPath) return Promise.resolve(configBody);
+      return Promise.reject(
+        new Error('Unexpected readTextFile: ' + String(path)),
+      );
+    },
+  );
+
+  // Prepare two .acf files in steamapps directory
+  const appsDir = join('/home/alice', '.steam', 'steam', 'steamapps');
+  const dirStub = stub(
+    Deno,
+    'readDir',
+    (path: string | URL): AsyncIterable<Deno.DirEntry> => {
+      if (String(path) !== appsDir) {
+        throw new Error('Unexpected readDir path: ' + String(path));
+      }
+      return makeDirEntries([
+        { name: 'appmanifest_111.acf', isFile: true },
+        { name: 'appmanifest_222.acf', isFile: true },
+        { name: 'notes.txt', isFile: true },
+      ]);
+    },
+  );
+
+  const files: Record<string, string> = {};
+  files[join(appsDir, 'appmanifest_111.acf')] = [
+    'AppState',
+    '{',
+    '\tappid\t111',
+    '\tname\tCool Game',
+    '}',
+  ].join('\n');
+  files[join(appsDir, 'appmanifest_222.acf')] = [
+    'AppState',
+    '{',
+    '\tappid\t222',
+    '\tname\tOther Game',
+    '}',
+  ].join('\n');
+
+  const readFileStub = stub(
+    Deno,
+    'readFile',
+    (path: string | URL): Promise<Uint8Array<ArrayBuffer>> => {
+      const body = files[String(path)];
+      if (!body) return Promise.reject(new Error('ENOENT: ' + String(path)));
+      return Promise.resolve(
+        new TextEncoder().encode(body) as unknown as Uint8Array<ArrayBuffer>,
+      );
+    },
+  );
+
+  try {
+    const mappings = await getProtonMappings();
+    // Sort by appid for deterministic comparison
+    const sorted = [...mappings].sort((a, b) => a.appid.localeCompare(b.appid));
+    // Expect two entries; one with mapped version, one with N/A
+    assertEquals(sorted, [
+      { appid: '111', name: 'Cool Game', protonVersion: 'Proton-8.0' },
+      { appid: '222', name: 'Other Game', protonVersion: 'N/A' },
+    ]);
+  } finally {
+    readFileStub.restore();
+    dirStub.restore();
+    readTextStub.restore();
+    envStub.restore();
+  }
+});
+
+Deno.test('getProtonMappings wraps errors as SteamyError', async () => {
+  const envStub = stub(
+    Deno.env,
+    'get',
+    (key: string) => (key === 'HOME' ? '/home/bad' : undefined),
+  );
+  const configPath = join(
+    '/home/bad',
+    '.steam',
+    'steam',
+    'config',
+    'config.vdf',
+  );
+  const readTextStub = stub(
+    Deno,
+    'readTextFile',
+    (path: string | URL): Promise<string> => {
+      if (String(path) === configPath) return Promise.reject(new Error('boom'));
+      return Promise.reject(new Error('Unexpected path'));
+    },
+  );
+
+  try {
+    await assertRejects(
+      () => getProtonMappings(),
+      SteamyError,
+      'Failed to access Steam directory: boom',
+    );
+  } finally {
+    readTextStub.restore();
+    envStub.restore();
+  }
+});
+
+Deno.test('getInstalledProtonVersions lists directories, ignores defaults, and honors overrides', async () => {
+  const dirPath = '/virtual/proton-prefix';
+  const dirStub = stub(
+    Deno,
+    'readDir',
+    (path: string | URL): AsyncIterable<Deno.DirEntry> => {
+      if (String(path) !== dirPath) {
+        throw new Error('Unexpected path: ' + String(path));
+      }
+      return makeDirEntries([
+        { name: 'Proton-9.0', isDirectory: true },
+        { name: 'LegacyRuntime', isDirectory: true },
+        { name: 'not-a-dir.txt', isFile: true },
+      ]);
+    },
+  );
+
+  try {
+    // Default ignore should filter out LegacyRuntime
+    const setDefault = await getInstalledProtonVersions({ rootDir: dirPath });
+    assertEquals(Array.from(setDefault).sort(), ['Proton-9.0']);
+
+    // Custom ignore overrides default
+    const setCustom = await getInstalledProtonVersions({
+      rootDir: dirPath,
+      ignoreVersions: [],
+    });
+    assertEquals(Array.from(setCustom).sort(), ['LegacyRuntime', 'Proton-9.0']);
+  } finally {
+    dirStub.restore();
+  }
+});
+
+Deno.test('getUnusedProtonVersions identifies versions not referenced by mappings', () => {
+  const mappings = [
+    { appid: '1', name: 'A', protonVersion: 'Proton-8.0' },
+  ];
+  const installed = ['Proton-7.0', 'Proton-8.0'];
+  const unused = getUnusedProtonVersions(mappings, installed);
+  assertEquals(unused, ['Proton-7.0']);
+});

--- a/src/core/steam/proton.ts
+++ b/src/core/steam/proton.ts
@@ -1,0 +1,87 @@
+import { join } from '@std/path';
+import { protonPrefixDir, steamRootDir } from './paths.ts';
+import { parseSteamCacheBody } from './cache-parser.ts';
+import { scanSteamCacheFragments } from '../games/match.ts';
+import { SteamyError } from '../errors.ts';
+import { IGNORE_VERSIONS } from '../../commands/proton/constants.ts';
+
+export type ProtonMapping = {
+  appid: string;
+  name: string;
+  protonVersion: string;
+};
+
+export async function getCompatToolMappings() {
+  const configCachePath = join(steamRootDir(), 'config', 'config.vdf');
+  const configCacheBody = await Deno.readTextFile(configCachePath);
+  const configCache = parseSteamCacheBody(configCacheBody) as {
+    InstallConfigStore: {
+      Software: {
+        Valve: {
+          Steam: {
+            CompatToolMapping: Record<string, { name: string }>;
+          };
+        };
+      };
+    };
+  };
+
+  return configCache.InstallConfigStore.Software.Valve.Steam.CompatToolMapping;
+}
+
+export async function getProtonMappings() {
+  try {
+    const compatToolMapping = await getCompatToolMappings();
+    const cacheFileFragments = await scanSteamCacheFragments();
+
+    return cacheFileFragments.map((fragment) => {
+      return {
+        appid: fragment.AppState.appid,
+        name: fragment.AppState.name,
+        protonVersion: compatToolMapping[fragment.AppState.appid]?.name ??
+          'N/A',
+      } satisfies ProtonMapping;
+    });
+  } catch (error: unknown) {
+    // Preserve existing error wrapping semantics
+    const errorMessage = error instanceof Error
+      ? error.message
+      : 'Unknown error';
+    throw new SteamyError(
+      `Failed to access Steam directory: ${errorMessage}`,
+      'STEAM_NOT_FOUND',
+      'Ensure Steam is installed and you have read permissions to the SteamApps directory',
+    );
+  }
+}
+
+export async function getInstalledProtonVersions({
+  rootDir,
+  ignoreVersions,
+}: {
+  rootDir?: string;
+  ignoreVersions?: string[];
+} = {}) {
+  const dir = rootDir ?? protonPrefixDir();
+  const ignore = ignoreVersions ?? IGNORE_VERSIONS;
+
+  const protonVersions = new Set<string>();
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isDirectory) {
+      if (!ignore.includes(entry.name)) {
+        protonVersions.add(entry.name);
+      }
+    }
+  }
+
+  return protonVersions;
+}
+
+export function getUnusedProtonVersions(
+  mappings: ProtonMapping[],
+  installed: string[],
+) {
+  return installed.filter(
+    (version) => !mappings.some((e) => e.protonVersion === version),
+  );
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -12,6 +12,14 @@ export type CacheFileFragment = {
   AppState: {
     appid: string;
     name: string;
+    installdir: string;
+    StateFlags: string;
+    DownloadType: string;
+    SizeOnDisk: string; // Bytes
+    UserConfig: {
+      highqualityaudio?: string;
+      language?: string;
+    };
   };
 };
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,0 +1,33 @@
+import { join } from '@std/path';
+
+export async function dirSize(dir: string) {
+  /* Example JS / Node implementation
+   * const files = await readdir( directory );
+  const stats = files.map( file => stat( path.join( directory, file ) ) );
+
+  return ( await Promise.all( stats ) ).reduce( ( accumulator, { size } ) => accumulator + size, 0 );
+   */
+
+  let size = 0;
+  const contents = Deno.readDir(dir);
+  for await (const entry of contents) {
+    if (entry.isDirectory) {
+      const subSize = await dirSize(join(dir, entry.name));
+      size += subSize;
+    } else if (entry.isFile) {
+      const stats = await Deno.stat(join(dir, entry.name));
+      size += stats.size;
+    }
+  }
+  return size;
+}
+
+export function sizeToHumanReadable(size: number) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let unitIndex = 0;
+  while (size > 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+  return `${size.toFixed(2)} ${units[unitIndex]}`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Command, ValidationError } from '@cliffy/command';
 import { openPrefix } from './commands/open-prefix.ts';
 import { launch } from './commands/launch.ts';
 import { gameTweaks } from './commands/game-tweaks/game-tweaks.ts';
+import { proton } from './commands/proton/proton.ts';
 import { getExitCode, SteamyError } from './core/errors.ts';
 
 try {
@@ -15,6 +16,7 @@ try {
     .command('openPrefix', openPrefix)
     .command('launch', launch)
     .command('gameTweaks', gameTweaks)
+    .command('proton', proton)
     .parse(Deno.args);
 } catch (e: unknown) {
   if (e instanceof SteamyError) {


### PR DESCRIPTION
Adds two commands:

- `steamy proton list` - Lists non-steam version of proton and what games are associated with them if any
- `steamy proton prune` - Provides the user with a way to select and remove non-steam versions of proton that are not being used by an installed game to reclaim disk space