### PR TITLE
fix getting proton release

### DIFF
--- a/src/commands/proton/commands/download.ts
+++ b/src/commands/proton/commands/download.ts
@@ -11,6 +11,7 @@ import { getInstalledProtonVersions } from '../../../core/steam/proton.ts';
 import { SteamyError } from '../../../core/errors.ts';
 import { startSpinner } from '../../../core/spinner.ts';
 import { getLatestRelease } from '../../../core/update/github-releases.ts';
+import { selectProtonTarball } from '../../../core/update/asset-selection.ts';
 
 const linuxHandler = async (logger: Logger) => {
   const rootDir = protonPrefixDir();
@@ -41,8 +42,9 @@ const linuxHandler = async (logger: Logger) => {
     // https://medium.com/deno-the-complete-reference/file-download-through-fetch-api-in-deno-771f30b19471
 
     // Download the release tarball
-    const asset = latestRelease.assets.find((e) =>
-      e.name === `${latestRelease.tag_name}.tar.gz`
+    const asset = selectProtonTarball(
+      latestRelease.assets,
+      latestRelease.tag_name,
     );
     const downloadUrl = asset?.browser_download_url;
     if (!asset || !downloadUrl) {
@@ -59,7 +61,7 @@ const linuxHandler = async (logger: Logger) => {
       } from ${downloadUrl}`,
     );
 
-    const tarballPath = `${protonPrefixDir()}/${latestRelease.tag_name}.tar.gz`;
+    const tarballPath = `${protonPrefixDir()}/${asset.name}`;
     const downloadSpinner = startSpinner({ text: 'Downloading' });
     try {
       const response = await fetch(downloadUrl);

--- a/src/core/update/asset-selection.test.ts
+++ b/src/core/update/asset-selection.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from '@std/assert';
+import { selectProtonTarball } from './asset-selection.ts';
+import type { GitHubReleaseAsset } from './types.ts';
+
+const makeAsset = (name: string): GitHubReleaseAsset => ({
+  name,
+  content_type: 'application/octet-stream',
+  browser_download_url: `https://example.com/${name}`,
+  size: 100,
+});
+
+Deno.test('selectProtonTarball - returns the single tarball among mixed assets', () => {
+  const assets = [
+    makeAsset('GE-Proton10-34.sha512sum'),
+    makeAsset('GE-Proton10-34.tar.gz'),
+  ];
+  const result = selectProtonTarball(assets, 'GE-Proton10-34');
+  assertEquals(result?.name, 'GE-Proton10-34.tar.gz');
+});
+
+Deno.test('selectProtonTarball - returns tarball even if name does not match tag', () => {
+  const assets = [
+    makeAsset('some-other-name.sha512sum'),
+    makeAsset('some-other-name.tar.gz'),
+  ];
+  const result = selectProtonTarball(assets, 'GE-Proton10-34');
+  assertEquals(result?.name, 'some-other-name.tar.gz');
+});
+
+Deno.test('selectProtonTarball - prefers tag-matching tarball when multiple exist', () => {
+  const assets = [
+    makeAsset('unrelated.tar.gz'),
+    makeAsset('GE-Proton10-34.tar.gz'),
+  ];
+  const result = selectProtonTarball(assets, 'GE-Proton10-34');
+  assertEquals(result?.name, 'GE-Proton10-34.tar.gz');
+});
+
+Deno.test('selectProtonTarball - returns undefined when no tarballs exist', () => {
+  const assets = [
+    makeAsset('GE-Proton10-34.sha512sum'),
+    makeAsset('GE-Proton10-34.sig'),
+  ];
+  const result = selectProtonTarball(assets, 'GE-Proton10-34');
+  assertEquals(result, undefined);
+});
+
+Deno.test('selectProtonTarball - returns undefined for empty assets', () => {
+  const result = selectProtonTarball([], 'GE-Proton10-34');
+  assertEquals(result, undefined);
+});
+
+Deno.test('selectProtonTarball - returns undefined when multiple tarballs and none match tag', () => {
+  const assets = [
+    makeAsset('foo.tar.gz'),
+    makeAsset('bar.tar.gz'),
+  ];
+  const result = selectProtonTarball(assets, 'GE-Proton10-34');
+  assertEquals(result, undefined);
+});

--- a/src/core/update/asset-selection.ts
+++ b/src/core/update/asset-selection.ts
@@ -1,0 +1,18 @@
+import type { GitHubReleaseAsset } from './types.ts';
+
+export function selectProtonTarball(
+  assets: GitHubReleaseAsset[],
+  tagName: string,
+): GitHubReleaseAsset | undefined {
+  const tarballs = assets.filter((a) => a.name.endsWith('.tar.gz'));
+
+  if (tarballs.length === 1) {
+    return tarballs[0];
+  }
+
+  if (tarballs.length > 1) {
+    return tarballs.find((a) => a.name === `${tagName}.tar.gz`);
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
The previous proton archive selection code was based off a flawed understanding of what is returned from the GH apis. This update will cause the archive to be grabbed with less fragility.